### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -16,7 +16,7 @@ time = {"hour": 8, "minute": 37, "second": 05, "hour": 12}
 
 # Invalid NoneType comparisons
 x = None
-if x == None:
+if x is None:
   print "Use is, not =="
 
 # Outdated <> operator


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:quantifiedcode:demo?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:quantifiedcode:demo?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)